### PR TITLE
First version code

### DIFF
--- a/mofulunches-totem/src/main/index.ts
+++ b/mofulunches-totem/src/main/index.ts
@@ -40,7 +40,7 @@ function createWindow(): void {
 }
 
 
-const rfid_middleware = spawn(join(__dirname, '../../resources/rfid_middleware/rfid_middleware'), ['-u']);
+const rfid_middleware = spawn(join(__dirname, '../../resources/ElDimon/ElDimon'), ['-u']);
 
 rfid_middleware.stdout.on('data', (data) => {
   console.log(`stdout: ${data}`);

--- a/mofulunches-totem/src/renderer/src/views/PedidoStatus.tsx
+++ b/mofulunches-totem/src/renderer/src/views/PedidoStatus.tsx
@@ -33,6 +33,7 @@ const PedidoStatus: React.FC = () => {
 
   // Check if pedido is already 'retirado'
   const isRetirado = pedido.estado === 'retirado';
+  const isListoParaRetirar = pedido.estado === 'listo_para_retirar';
 
   const handleShow = () => setShowModal(true);
   const handleClose = () => setShowModal(false);
@@ -92,6 +93,11 @@ const PedidoStatus: React.FC = () => {
                   <FontAwesomeIcon icon={faExclamationCircle} className="ms-2" /> Este pedido ya ha sido retirado y no puede ser actualizado.
                 </p>
               )}
+              {!isRetirado && !isListoParaRetirar && (
+                <p className="text-warning">
+                  <FontAwesomeIcon icon={faExclamationCircle} className="ms-2" /> El pedido no está listo para retirar.
+                </p>
+              )}
               <button className="btn btn-info mt-2" onClick={handleShow}>
                 <FontAwesomeIcon icon={faEye} className="me-2" /> Ver contenido
               </button>
@@ -106,7 +112,7 @@ const PedidoStatus: React.FC = () => {
             </div>
           </div>
           <div className="button-group mt-4 d-flex justify-content-center gap-3">
-            {!isRetirado && (
+            {!isRetirado && isListoParaRetirar && (
               <button className="btn btn-success" onClick={handleConfirmShow}>
                 <FontAwesomeIcon icon={faCheckCircle} className="me-2" /> Retirar pedido
               </button>


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend of the `mofulunches-totem` project. The primary focus is on updating the middleware path in the backend and enhancing the order status handling in the frontend.

Backend changes:

* [`mofulunches-totem/src/main/index.ts`](diffhunk://#diff-befeea7fbd5f70a3840f0730b6442986958ddee9e96f346ffd9275d638ba821eL43-R43): Updated the path of the `rfid_middleware` to use a new directory `ElDimon`.

Frontend changes:

* [`mofulunches-totem/src/renderer/src/views/PedidoStatus.tsx`](diffhunk://#diff-b1f65e8aea85457fc13558e3228ac012ffc5daa9f0f873635dbb198f7af1cb8cR36): Added a new state check `isListoParaRetirar` to determine if an order is ready for pickup.
* [`mofulunches-totem/src/renderer/src/views/PedidoStatus.tsx`](diffhunk://#diff-b1f65e8aea85457fc13558e3228ac012ffc5daa9f0f873635dbb198f7af1cb8cR96-R100): Added a warning message when the order is not ready for pickup.
* [`mofulunches-totem/src/renderer/src/views/PedidoStatus.tsx`](diffhunk://#diff-b1f65e8aea85457fc13558e3228ac012ffc5daa9f0f873635dbb198f7af1cb8cL109-R115): Updated the button logic to only show the "Retirar pedido" button when the order is ready for pickup.